### PR TITLE
[Issue 19] Remove imageDigest if present when updating imageTag in container update

### DIFF
--- a/container-update-image/.lib-action/index.js
+++ b/container-update-image/.lib-action/index.js
@@ -24971,9 +24971,6 @@ function run() {
                     return;
                 }
                 appConfig.containerTemplates[index].imageTag = imageTag;
-                // If imageDigest is set, we need to remove it, because it seems to
-                // take presedence over imageTag.
-                delete appConfig.containerTemplates[index].imageDigest;
                 replaced = true;
             });
             if (replaced === false) {
@@ -24982,11 +24979,11 @@ function run() {
             yield saveAppConfiguration(token, appId, appConfig);
         }
         catch (e) {
-            if (typeof e === "string" || e instanceof Error) {
+            if (typeof e === 'string' || e instanceof Error) {
                 core.setFailed(e);
             }
             else {
-                core.setFailed("Unexpected error");
+                core.setFailed('Unexpected error');
             }
         }
     });
@@ -24994,36 +24991,35 @@ function run() {
 function exchangeApiKeyForToken(apiKey) {
     return __awaiter(this, void 0, void 0, function* () {
         return new Promise((resolve, reject) => {
-            fetch("https://api.bunny.net/apikey/exchange", {
-                method: "POST",
+            fetch('https://api.bunny.net/apikey/exchange', {
+                method: 'POST',
                 headers: {
-                    "Content-Type": "application/json",
-                    AccessKey: apiKey,
+                    'Content-Type': 'application/json',
+                    'AccessKey': apiKey,
                 },
                 body: JSON.stringify({ AccessKey: apiKey }),
             })
-                .then((response) => {
+                .then(response => {
                 if (response.status === 401) {
-                    reject("Invalid api_key.");
+                    reject('Invalid api_key.');
                     return;
                 }
                 if (response.status !== 200) {
                     reject(`Could not obtain access token: HTTP status ${response.status}.`);
                     return;
                 }
-                response
-                    .json()
-                    .then((obj) => {
+                response.json()
+                    .then(obj => {
                     resolve(obj.Token);
                 })
-                    .catch((e) => {
+                    .catch(e => {
                     console.log(e);
-                    reject("Could not parse JSON response.");
+                    reject('Could not parse JSON response.');
                 });
             })
-                .catch((e) => {
+                .catch(e => {
                 console.log(e);
-                reject("Could not obtain access token.");
+                reject('Could not obtain access token.');
             });
         });
     });
@@ -25032,13 +25028,13 @@ function getAppConfiguration(token, appId) {
     return __awaiter(this, void 0, void 0, function* () {
         return new Promise((resolve, reject) => {
             fetch(`https://api-mc.opsbunny.net/v1/namespaces/default/applications/${appId}/configuration`, {
-                method: "GET",
+                method: 'GET',
                 headers: {
-                    Accept: "application/json",
-                    Authorization: token,
+                    'Accept': 'application/json',
+                    'Authorization': token
                 },
             })
-                .then((response) => {
+                .then(response => {
                 if (response.status === 400) {
                     reject(`Could not obtain app configuration: Double-check your app_id.`);
                     return;
@@ -25047,19 +25043,18 @@ function getAppConfiguration(token, appId) {
                     reject(`Could not obtain app configuration: HTTP status ${response.status}.`);
                     return;
                 }
-                response
-                    .json()
-                    .then((obj) => {
+                response.json()
+                    .then(obj => {
                     resolve(obj);
                 })
-                    .catch((e) => {
+                    .catch(e => {
                     console.log(e);
-                    reject("Could not parse JSON response.");
+                    reject('Could not parse JSON response.');
                 });
             })
-                .catch((e) => {
+                .catch(e => {
                 console.log(e);
-                reject("Could not obtain app configuration.");
+                reject('Could not obtain app configuration.');
             });
         });
     });
@@ -25067,24 +25062,24 @@ function getAppConfiguration(token, appId) {
 function saveAppConfiguration(token, appId, appConfig) {
     return __awaiter(this, void 0, void 0, function* () {
         return new Promise((resolve, reject) => {
-            fetch("https://api-mc.opsbunny.net/v1/namespaces/default/applications", {
-                method: "PUT",
+            fetch('https://api-mc.opsbunny.net/v1/namespaces/default/applications', {
+                method: 'PUT',
                 headers: {
-                    "Content-Type": "application/json",
-                    Authorization: token,
+                    'Content-Type': 'application/json',
+                    'Authorization': token
                 },
                 body: JSON.stringify(appConfig),
             })
-                .then((response) => {
+                .then(response => {
                 if (response.status !== 200) {
                     reject(`Could not save app configuration: HTTP status ${response.status}.`);
                     return;
                 }
                 resolve();
             })
-                .catch((e) => {
+                .catch(e => {
                 console.log(e);
-                reject("Could not save app configuration.");
+                reject('Could not save app configuration.');
             });
         });
     });

--- a/container-update-image/.lib-action/index.js
+++ b/container-update-image/.lib-action/index.js
@@ -24971,6 +24971,9 @@ function run() {
                     return;
                 }
                 appConfig.containerTemplates[index].imageTag = imageTag;
+                // If imageDigest is set, we need to remove it, because it seems to
+                // take presedence over imageTag.
+                delete appConfig.containerTemplates[index].imageDigest;
                 replaced = true;
             });
             if (replaced === false) {
@@ -24979,11 +24982,11 @@ function run() {
             yield saveAppConfiguration(token, appId, appConfig);
         }
         catch (e) {
-            if (typeof e === 'string' || e instanceof Error) {
+            if (typeof e === "string" || e instanceof Error) {
                 core.setFailed(e);
             }
             else {
-                core.setFailed('Unexpected error');
+                core.setFailed("Unexpected error");
             }
         }
     });
@@ -24991,35 +24994,36 @@ function run() {
 function exchangeApiKeyForToken(apiKey) {
     return __awaiter(this, void 0, void 0, function* () {
         return new Promise((resolve, reject) => {
-            fetch('https://api.bunny.net/apikey/exchange', {
-                method: 'POST',
+            fetch("https://api.bunny.net/apikey/exchange", {
+                method: "POST",
                 headers: {
-                    'Content-Type': 'application/json',
-                    'AccessKey': apiKey,
+                    "Content-Type": "application/json",
+                    AccessKey: apiKey,
                 },
                 body: JSON.stringify({ AccessKey: apiKey }),
             })
-                .then(response => {
+                .then((response) => {
                 if (response.status === 401) {
-                    reject('Invalid api_key.');
+                    reject("Invalid api_key.");
                     return;
                 }
                 if (response.status !== 200) {
                     reject(`Could not obtain access token: HTTP status ${response.status}.`);
                     return;
                 }
-                response.json()
-                    .then(obj => {
+                response
+                    .json()
+                    .then((obj) => {
                     resolve(obj.Token);
                 })
-                    .catch(e => {
+                    .catch((e) => {
                     console.log(e);
-                    reject('Could not parse JSON response.');
+                    reject("Could not parse JSON response.");
                 });
             })
-                .catch(e => {
+                .catch((e) => {
                 console.log(e);
-                reject('Could not obtain access token.');
+                reject("Could not obtain access token.");
             });
         });
     });
@@ -25028,13 +25032,13 @@ function getAppConfiguration(token, appId) {
     return __awaiter(this, void 0, void 0, function* () {
         return new Promise((resolve, reject) => {
             fetch(`https://api-mc.opsbunny.net/v1/namespaces/default/applications/${appId}/configuration`, {
-                method: 'GET',
+                method: "GET",
                 headers: {
-                    'Accept': 'application/json',
-                    'Authorization': token
+                    Accept: "application/json",
+                    Authorization: token,
                 },
             })
-                .then(response => {
+                .then((response) => {
                 if (response.status === 400) {
                     reject(`Could not obtain app configuration: Double-check your app_id.`);
                     return;
@@ -25043,18 +25047,19 @@ function getAppConfiguration(token, appId) {
                     reject(`Could not obtain app configuration: HTTP status ${response.status}.`);
                     return;
                 }
-                response.json()
-                    .then(obj => {
+                response
+                    .json()
+                    .then((obj) => {
                     resolve(obj);
                 })
-                    .catch(e => {
+                    .catch((e) => {
                     console.log(e);
-                    reject('Could not parse JSON response.');
+                    reject("Could not parse JSON response.");
                 });
             })
-                .catch(e => {
+                .catch((e) => {
                 console.log(e);
-                reject('Could not obtain app configuration.');
+                reject("Could not obtain app configuration.");
             });
         });
     });
@@ -25062,24 +25067,24 @@ function getAppConfiguration(token, appId) {
 function saveAppConfiguration(token, appId, appConfig) {
     return __awaiter(this, void 0, void 0, function* () {
         return new Promise((resolve, reject) => {
-            fetch('https://api-mc.opsbunny.net/v1/namespaces/default/applications', {
-                method: 'PUT',
+            fetch("https://api-mc.opsbunny.net/v1/namespaces/default/applications", {
+                method: "PUT",
                 headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': token
+                    "Content-Type": "application/json",
+                    Authorization: token,
                 },
                 body: JSON.stringify(appConfig),
             })
-                .then(response => {
+                .then((response) => {
                 if (response.status !== 200) {
                     reject(`Could not save app configuration: HTTP status ${response.status}.`);
                     return;
                 }
                 resolve();
             })
-                .catch(e => {
+                .catch((e) => {
                 console.log(e);
-                reject('Could not save app configuration.');
+                reject("Could not save app configuration.");
             });
         });
     });

--- a/container-update-image/src/action.ts
+++ b/container-update-image/src/action.ts
@@ -28,129 +28,113 @@ export async function run() {
 
     await saveAppConfiguration(token, appId, appConfig);
   } catch (e) {
-    if (typeof e === "string" || e instanceof Error) {
+    if (typeof e === 'string' || e instanceof Error) {
       core.setFailed(e);
     } else {
-      core.setFailed("Unexpected error");
+      core.setFailed('Unexpected error');
     }
   }
 }
 
 async function exchangeApiKeyForToken(apiKey: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    fetch("https://api.bunny.net/apikey/exchange", {
-      method: "POST",
+    fetch('https://api.bunny.net/apikey/exchange', {
+      method: 'POST',
       headers: {
-        "Content-Type": "application/json",
-        AccessKey: apiKey,
+        'Content-Type': 'application/json',
+        'AccessKey': apiKey,
       },
       body: JSON.stringify({ AccessKey: apiKey }),
     })
-      .then((response) => {
+      .then(response => {
         if (response.status === 401) {
-          reject("Invalid api_key.");
+          reject('Invalid api_key.');
           return;
         }
 
         if (response.status !== 200) {
-          reject(
-            `Could not obtain access token: HTTP status ${response.status}.`
-          );
+          reject(`Could not obtain access token: HTTP status ${response.status}.`);
           return;
         }
 
-        response
-          .json()
-          .then((obj) => {
+        response.json()
+          .then(obj => {
             resolve(obj.Token);
           })
-          .catch((e) => {
+          .catch(e => {
             console.log(e);
-            reject("Could not parse JSON response.");
-          });
+            reject('Could not parse JSON response.');
+          })
+        ;
       })
-      .catch((e) => {
+      .catch(e => {
         console.log(e);
-        reject("Could not obtain access token.");
+        reject('Could not obtain access token.');
       });
   });
 }
 
-async function getAppConfiguration(
-  token: string,
-  appId: string
-): Promise<AppConfiguration> {
+async function getAppConfiguration(token: string, appId: string): Promise<AppConfiguration> {
   return new Promise((resolve, reject) => {
-    fetch(
-      `https://api-mc.opsbunny.net/v1/namespaces/default/applications/${appId}/configuration`,
-      {
-        method: "GET",
-        headers: {
-          Accept: "application/json",
-          Authorization: token,
-        },
-      }
-    )
-      .then((response) => {
+    fetch(`https://api-mc.opsbunny.net/v1/namespaces/default/applications/${appId}/configuration`, {
+      method: 'GET',
+      headers: {
+        'Accept': 'application/json',
+        'Authorization': token
+      },
+    })
+      .then(response => {
         if (response.status === 400) {
-          reject(
-            `Could not obtain app configuration: Double-check your app_id.`
-          );
+          reject(`Could not obtain app configuration: Double-check your app_id.`);
           return;
         }
 
         if (response.status !== 200) {
-          reject(
-            `Could not obtain app configuration: HTTP status ${response.status}.`
-          );
+          reject(`Could not obtain app configuration: HTTP status ${response.status}.`);
           return;
         }
 
-        response
-          .json()
-          .then((obj) => {
+        response.json()
+          .then(obj => {
             resolve(obj);
           })
-          .catch((e) => {
+          .catch(e => {
             console.log(e);
-            reject("Could not parse JSON response.");
-          });
+            reject('Could not parse JSON response.');
+          })
+        ;
       })
-      .catch((e) => {
+      .catch(e => {
         console.log(e);
-        reject("Could not obtain app configuration.");
-      });
+        reject('Could not obtain app configuration.');
+      })
+    ;
   });
 }
 
-async function saveAppConfiguration(
-  token: string,
-  appId: string,
-  appConfig: AppConfiguration
-): Promise<void> {
+async function saveAppConfiguration(token: string, appId: string, appConfig: AppConfiguration): Promise<void> {
   return new Promise((resolve, reject) => {
-    fetch("https://api-mc.opsbunny.net/v1/namespaces/default/applications", {
-      method: "PUT",
+    fetch('https://api-mc.opsbunny.net/v1/namespaces/default/applications', {
+      method: 'PUT',
       headers: {
-        "Content-Type": "application/json",
-        Authorization: token,
+        'Content-Type': 'application/json',
+        'Authorization': token
       },
       body: JSON.stringify(appConfig),
     })
-      .then((response) => {
+      .then(response => {
         if (response.status !== 200) {
-          reject(
-            `Could not save app configuration: HTTP status ${response.status}.`
-          );
+          reject(`Could not save app configuration: HTTP status ${response.status}.`);
           return;
         }
 
         resolve();
       })
-      .catch((e) => {
+      .catch(e => {
         console.log(e);
-        reject("Could not save app configuration.");
-      });
+        reject('Could not save app configuration.');
+      })
+    ;
   });
 }
 
@@ -161,4 +145,4 @@ type AppConfiguration = {
     imageTag: string;
     imageDigest?: string;
   }>;
-};
+}

--- a/container-update-image/src/action.ts
+++ b/container-update-image/src/action.ts
@@ -16,6 +16,9 @@ export async function run() {
         return;
       }
       appConfig.containerTemplates[index].imageTag = imageTag;
+      // If imageDigest is set, we need to remove it, because it seems to
+      // take presedence over imageTag.
+      delete appConfig.containerTemplates[index].imageDigest;
       replaced = true;
     });
 
@@ -25,113 +28,129 @@ export async function run() {
 
     await saveAppConfiguration(token, appId, appConfig);
   } catch (e) {
-    if (typeof e === 'string' || e instanceof Error) {
+    if (typeof e === "string" || e instanceof Error) {
       core.setFailed(e);
     } else {
-      core.setFailed('Unexpected error');
+      core.setFailed("Unexpected error");
     }
   }
 }
 
 async function exchangeApiKeyForToken(apiKey: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    fetch('https://api.bunny.net/apikey/exchange', {
-      method: 'POST',
+    fetch("https://api.bunny.net/apikey/exchange", {
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
-        'AccessKey': apiKey,
+        "Content-Type": "application/json",
+        AccessKey: apiKey,
       },
       body: JSON.stringify({ AccessKey: apiKey }),
     })
-      .then(response => {
+      .then((response) => {
         if (response.status === 401) {
-          reject('Invalid api_key.');
+          reject("Invalid api_key.");
           return;
         }
 
         if (response.status !== 200) {
-          reject(`Could not obtain access token: HTTP status ${response.status}.`);
+          reject(
+            `Could not obtain access token: HTTP status ${response.status}.`
+          );
           return;
         }
 
-        response.json()
-          .then(obj => {
+        response
+          .json()
+          .then((obj) => {
             resolve(obj.Token);
           })
-          .catch(e => {
+          .catch((e) => {
             console.log(e);
-            reject('Could not parse JSON response.');
-          })
-        ;
+            reject("Could not parse JSON response.");
+          });
       })
-      .catch(e => {
+      .catch((e) => {
         console.log(e);
-        reject('Could not obtain access token.');
+        reject("Could not obtain access token.");
       });
   });
 }
 
-async function getAppConfiguration(token: string, appId: string): Promise<AppConfiguration> {
+async function getAppConfiguration(
+  token: string,
+  appId: string
+): Promise<AppConfiguration> {
   return new Promise((resolve, reject) => {
-    fetch(`https://api-mc.opsbunny.net/v1/namespaces/default/applications/${appId}/configuration`, {
-      method: 'GET',
-      headers: {
-        'Accept': 'application/json',
-        'Authorization': token
-      },
-    })
-      .then(response => {
+    fetch(
+      `https://api-mc.opsbunny.net/v1/namespaces/default/applications/${appId}/configuration`,
+      {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+          Authorization: token,
+        },
+      }
+    )
+      .then((response) => {
         if (response.status === 400) {
-          reject(`Could not obtain app configuration: Double-check your app_id.`);
+          reject(
+            `Could not obtain app configuration: Double-check your app_id.`
+          );
           return;
         }
 
         if (response.status !== 200) {
-          reject(`Could not obtain app configuration: HTTP status ${response.status}.`);
+          reject(
+            `Could not obtain app configuration: HTTP status ${response.status}.`
+          );
           return;
         }
 
-        response.json()
-          .then(obj => {
+        response
+          .json()
+          .then((obj) => {
             resolve(obj);
           })
-          .catch(e => {
+          .catch((e) => {
             console.log(e);
-            reject('Could not parse JSON response.');
-          })
-        ;
+            reject("Could not parse JSON response.");
+          });
       })
-      .catch(e => {
+      .catch((e) => {
         console.log(e);
-        reject('Could not obtain app configuration.');
-      })
-    ;
+        reject("Could not obtain app configuration.");
+      });
   });
 }
 
-async function saveAppConfiguration(token: string, appId: string, appConfig: AppConfiguration): Promise<void> {
+async function saveAppConfiguration(
+  token: string,
+  appId: string,
+  appConfig: AppConfiguration
+): Promise<void> {
   return new Promise((resolve, reject) => {
-    fetch('https://api-mc.opsbunny.net/v1/namespaces/default/applications', {
-      method: 'PUT',
+    fetch("https://api-mc.opsbunny.net/v1/namespaces/default/applications", {
+      method: "PUT",
       headers: {
-        'Content-Type': 'application/json',
-        'Authorization': token
+        "Content-Type": "application/json",
+        Authorization: token,
       },
       body: JSON.stringify(appConfig),
     })
-      .then(response => {
+      .then((response) => {
         if (response.status !== 200) {
-          reject(`Could not save app configuration: HTTP status ${response.status}.`);
+          reject(
+            `Could not save app configuration: HTTP status ${response.status}.`
+          );
           return;
         }
 
         resolve();
       })
-      .catch(e => {
+      .catch((e) => {
         console.log(e);
-        reject('Could not save app configuration.');
-      })
-    ;
+        reject("Could not save app configuration.");
+      });
   });
 }
 
@@ -140,5 +159,6 @@ type AppConfiguration = {
   containerTemplates: Array<{
     name: string;
     imageTag: string;
+    imageDigest?: string;
   }>;
-}
+};


### PR DESCRIPTION
This action currently does not update the image when the existing spec includes both an `imageTag`  and `imageDigest`, which it will if the Web UI is used to update the image tag. If only the `imageTag` is updated, the container service appears to save the new `imageTag` but continues to use the image specified by `imageDigest`. Removing the `imageDigest` field when updating `imageTag` fixes this.

#19 